### PR TITLE
Revert GPU ID override by Xiaomi for whyred

### DIFF
--- a/arch/arm/boot/dts/qcom/sdm636.dtsi
+++ b/arch/arm/boot/dts/qcom/sdm636.dtsi
@@ -72,9 +72,3 @@
 		/delete-node/ qcom,msm_fastrpc_compute_cb13;
 	};
 };
-
-/* GPU overrides */
-&msm_gpu {
-		/* Update GPU chip ID*/
-		qcom,chipid = <0x05000900>;
-};


### PR DESCRIPTION
With override, sdm636's GPU will be rightly shown as Adreno 509.
But if the GPU ID not overridden with the exact ID, it gets detected as 660's GPU which is Adreno 512.
Choosing to show default GPU over right one benefits in better gaming capablities like HD option in PUBG.