### PR TITLE
mdss: mdp: Default to 258 kcal saturation

### DIFF
--- a/drivers/video/fbdev/msm/mdss_mdp_kcal_ctrl.c
+++ b/drivers/video/fbdev/msm/mdss_mdp_kcal_ctrl.c
@@ -35,7 +35,7 @@
 
 #define DEF_PCC 0x100
 #define DEF_PA 0xff
-#define DEF_SAT 270
+#define DEF_SAT 258
 #define PCC_ADJ 0x80
 
 struct kcal_lut_data {


### PR DESCRIPTION
This is the stock saturation value of the display, equivalent to 33% on Xiaomi parts.